### PR TITLE
Slight build system changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -356,7 +356,7 @@ DX_INIT_DOXYGEN([$PACKAGE_NAME], [doc/resources/doxygen.cfg], [doc])
 # Output
 ######################################################################
 DEPS_LIBS="$DEPS_LIBS $LIBREFLEX $LIBWNN"
-CXXFLAGS="$CFLAGS"
+CXXFLAGS="$CXXFLAGS $CFLAGS"
 
 with_surface_events=no
 if test -n "$DFB_SURFACE_EVENTS"; then

--- a/ilixi/lib/InputHelperJP.cpp
+++ b/ilixi/lib/InputHelperJP.cpp
@@ -26,7 +26,9 @@
 #include <lib/utf8.h>
 #include <core/Logger.h>
 #include <directfb.h>
+#if ILIXI_HAVE_LIBWNN
 #include <iconv.h>
+#endif
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
Both changes are made with the goal of making it somewhat easier to cross compile for some embedded systems. 

The first one propagates CXXFLAGS into the configuration scripts. You could achieve the same effect before with CFLAGS, but it would give warnings if the flags were C++ specific. 

The second one only includes iconv.h if it will be required with the current system setup. Including it otherwise is normally harmless; except on systems which don't have locale support and so don't typically have iconv.h available.  
